### PR TITLE
IPv6 support + a small fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,16 @@
     group: root
     mode: 0644
 
-- name: Hostname | Update the hostname (pt. 3) - (/etc/hosts)
+- name: Hostname | Update the IPv4 hostname (pt. 3) - (/etc/hosts)
   lineinfile:
     dest: /etc/hosts
     regexp: "^127.0.0.1"
     line: "127.0.0.1{{'\t'}}{{inventory_hostname}}{% if inventory_hostname != inventory_hostname_short %}{{'\t'}}{{inventory_hostname_short}}{% endif %}{{'\t'}}localhost"
+    state: present
+
+- name: Hostname | Update the IPv6 hostname (pt. 3) - (/etc/hosts)
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^::1"
+    line: "::1{{'\t\t'}}{{inventory_hostname}}{% if inventory_hostname != inventory_hostname_short %}{{'\t'}}{{inventory_hostname_short}}{% endif %}{{'\t'}}localhost ip6-localhost ip6-loopback"
     state: present


### PR DESCRIPTION
This PR adds support for changing the IPv6 names along with the IPv4 names, keeping the original extra names as well.

Also makes sure that /etc/hostname has a newline at the end, as most tools work best when that is the case.  The debian scripts work fine when this is the case.
