### PR TITLE
optionally install avahi for mdns support (useful in vagrant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ Ansible role that sets the hostname and FQDN of the node.
 
 #### Variables
 
-This role fully depends on your ansible hosts inventory.
+This depends on your ansible hosts inventory.
 
 Add the hosts to your inventory with their FQDN (e.g. foo.bar.com), and the role will take care of setting your hostname accordingly (hostname: foo, FQDN: foo.bar.com).
 
 If you just name it with the hostname in the inventory, it will similarly work (hostname set, but no FQDN attached to it).
 
+```yaml
+hostname_avahi: no              # You may optionall install avahi-mdns. This is useful in vagrant.
+```
 
 #### Example
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+hostname_avahi = ENV.key?('hostname_avahi') ? ENV['hostname_avahi'] : 'false'
 Vagrant.configure('2') do |config|
   config.vm.define 'anxs' do |c|
     c.vm.box = 'ubuntu/trusty64'
@@ -11,6 +12,9 @@ Vagrant.configure('2') do |config|
       ansible.sudo = true
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
+      ansible.extra_vars = {
+        hostname_avahi: hostname_avahi
+      }
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-hostname_avahi = ENV.key?('hostname_avahi') ? ENV['hostname_avahi'] : 'false'
+hostname_avahi = ENV.key?('HOSTNAME_AVAHI') ? ENV['HOSTNAME_AVAHI'] : 'false'
 Vagrant.configure('2') do |config|
   config.vm.define 'anxs' do |c|
     c.vm.box = 'ubuntu/trusty64'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+# file: hostname/defaults/main.yml
+
+hostname_avahi: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,6 @@ galaxy_info:
   categories:
   - system
 
-dependencies: []
+dependencies: 
+  - role: ANXS.apt
+    when: hostname_avahi|lower == "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,3 +25,7 @@
     regexp: "^::1"
     line: "::1{{'\t\t'}}{{inventory_hostname}}{% if inventory_hostname != inventory_hostname_short %}{{'\t'}}{{inventory_hostname_short}}{% endif %}{{'\t'}}localhost ip6-localhost ip6-loopback"
     state: present
+
+- name: Hostname | Install Avahi-MDNS
+  apt: pkg=avahi-daemon state=latest
+  when: "'{{ansible_os_family}}' == 'Debian' and {{hostname_avahi}}"

--- a/test.yml
+++ b/test.yml
@@ -1,3 +1,5 @@
 - hosts: all
+  vars_files:
+    - 'defaults/main.yml'
   tasks:
     - include: 'tasks/main.yml'


### PR DESCRIPTION
Worked for me locally! Pretty sure we don't need to support uninstalling avahi...