### PR TITLE
Install dbus if not exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 # file: hostname/tasks/main.yml
 
+- name: Hostname | Ensure dbus installed
+  apt:
+    name: dbus
+    state: installed
+  tags: hostname
+
 - name: Hostname | Update the hostname (pt. 1) - hostname cmd
   hostname:
     name: "{{inventory_hostname_short}}"


### PR DESCRIPTION
For prevent error "Failed to create bus connection: No such file or directory" on some images with clean Ubuntu 16.04

https://serverfault.com/questions/685837/how-to-set-the-hostname-for-a-debian-jessie-system