### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Hostname | Ensure dbus installed
   apt:
     name: "{{anxs_hostname_packages}}"
-    state: installed
+    state: present
   tags: hostname
   when: ansible_os_family == "Debian"
 
@@ -35,5 +35,5 @@
 - name: Hostname | Install MDNS Components
   apt:
     name: "{{anxs_hostname_mdns_packages}}"
-    state: installed
+    state: present
   when: 'ansible_os_family == "Debian" and hostname_avahi'


### PR DESCRIPTION
Fixes
```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.. This
feature will be removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```